### PR TITLE
Use work area instead of whole monitor

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,8 +31,9 @@ class Extension {
   moveWindow(location) {
     global.get_window_actors().every((w) => {
       if (w.meta_window.has_focus()) {
-        var monitorGeometry = global.display.get_monitor_geometry(
-          w.meta_window.get_monitor(),
+        const workspace = global.workspace_manager.get_active_workspace();
+        var monitorGeometry = workspace.get_work_area_for_monitor(
+          w.meta_window.get_monitor().index,
         );
         var monitorUpperLeftX = monitorGeometry.x;
         var monitorUpperLeftY = monitorGeometry.y;


### PR DESCRIPTION
Firstly, thanks for the great extension!
Currently the extension uses the size of the monitor as a reference for calculating the window sizes. This becomes an issue if the usable work area does not fill the whole monitor, for example if a GNOME extension like `Window List` is used. I changed the reference to the work area of the current active workspace, which takes this into consideration.